### PR TITLE
Fix: Parameters not added to Uri objects.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -284,6 +284,7 @@ class WeatherApiInterceptor implements InterceptorContract {
     } catch (e) {
       print(e);
     }
+    print(data.params);
     return data;
   }
 

--- a/lib/http_client_with_interceptor.dart
+++ b/lib/http_client_with_interceptor.dart
@@ -132,7 +132,13 @@ class HttpClientWithInterceptor extends http.BaseClient {
     dynamic body,
     Encoding encoding,
   }) async {
-    if (url is String) url = Uri.parse(addParametersToUrl(url, params));
+    if (url is String) {
+      url = Uri.parse(addParametersToStringUrl(url, params));
+    } else if (url is Uri) {
+      url = addParametersToUrl(url, params);
+    } else {
+      throw HttpInterceptorException("Malformed URL parameter");
+    }
 
     Request request = new Request(methodToString(method), url);
     if (headers != null) request.headers.addAll(headers);

--- a/lib/http_client_with_interceptor.dart
+++ b/lib/http_client_with_interceptor.dart
@@ -156,7 +156,7 @@ class HttpClientWithInterceptor extends http.BaseClient {
     }
 
     // Intercept request
-    await _interceptRequest(request);
+    request = await _interceptRequest(request);
 
     var stream = requestTimeout == null
         ? await send(request)

--- a/lib/models/http_interceptor_exception.dart
+++ b/lib/models/http_interceptor_exception.dart
@@ -1,0 +1,12 @@
+
+
+class HttpInterceptorException implements Exception {
+  final message;
+
+  HttpInterceptorException([this.message]);
+
+  String toString() {
+    if (message == null) return "Exception";
+    return "Exception: $message";
+  }
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,2 +1,3 @@
 export 'request_data.dart';
 export 'response_data.dart';
+export 'http_interceptor_exception.dart';

--- a/lib/models/request_data.dart
+++ b/lib/models/request_data.dart
@@ -23,7 +23,7 @@ class RequestData {
   })  : assert(method != null),
         assert(baseUrl != null);
 
-  String get url => addParametersToUrl(baseUrl, params);
+  String get url => addParametersToStringUrl(baseUrl, params);
 
   factory RequestData.fromHttpRequest(Request request) {
     var params = Map<String, String>();
@@ -42,7 +42,7 @@ class RequestData {
   }
 
   Request toHttpRequest() {
-    var reqUrl = Uri.parse(addParametersToUrl(baseUrl, params));
+    var reqUrl = Uri.parse(addParametersToStringUrl(baseUrl, params));
     
     Request request = new Request(methodToString(method), reqUrl);
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,18 +1,48 @@
 /// When having an URL as String and no parameters sent then it adds
 /// them to the string.
-String addParametersToUrl(String url, Map<String, String> parameters) {
+String addParametersToStringUrl(String url, Map<String, String> parameters) {
+  return buildUrlString(url, parameters);
+}
+
+Uri addParametersToUrl(Uri url, Map<String, String> parameters) {
   if (parameters == null) return url;
 
-  String paramUrl = url;
-  if (parameters != null && parameters.length > 0) {
-    if (paramUrl.contains("?"))
-      paramUrl += "&";
-    else
-      paramUrl += "?";
+  String paramUrl = url.origin + url.path;
+
+  Map<String, String> newParameters = {};
+
+  url.queryParameters.forEach((key, value) {
+    newParameters[key] = value;
+  });
+
+  parameters.forEach((key, value) {
+    newParameters[key] = value;
+  });
+
+  return Uri.parse(buildUrlString(paramUrl, newParameters));
+}
+
+String buildUrlString(String url, Map<String, String> parameters) {
+  // Avoids unnecessary processing.
+  if (parameters == null) return url;
+
+  // Check if there are parameters to add.
+  if (parameters.length > 0) {
+    // Checks if the string url already has parameters.
+    if (url.contains("?")) {
+      url += "&";
+    } else {
+      url += "?";
+    }
+
+    // Concat every parameter to the string url.
     parameters.forEach((key, value) {
-      paramUrl += "$key=$value&";
+      url += "$key=$value&";
     });
-    paramUrl = paramUrl.substring(0, paramUrl.length - 1);
+
+    // Remove last '&' character.
+    url = url.substring(0, url.length - 1);
   }
-  return paramUrl;
+
+  return url;
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -2,14 +2,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http_interceptor/utils.dart';
 
 main() {
-  group("addParametersToUrl", () {
+  group("addParametersToStringUrl", () {
     test("Adds parameters to a URL string without parameters", () {
       // Arrange
       String url = "https://www.google.com/helloworld";
       Map<String, String> parameters = {"foo": "bar", "num": "0"};
 
       // Act
-      String parameterUrl = addParametersToUrl(url, parameters);
+      String parameterUrl = addParametersToStringUrl(url, parameters);
 
       // Assert
       expect(parameterUrl,
@@ -21,13 +21,44 @@ main() {
       Map<String, String> parameters = {"extra": "1", "extra2": "anotherone"};
 
       // Act
-      String parameterUrl = addParametersToUrl(url, parameters);
+      String parameterUrl = addParametersToStringUrl(url, parameters);
 
       // Assert
       expect(
           parameterUrl,
           equals(
               "https://www.google.com/helloworld?foo=bar&num=0&extra=1&extra2=anotherone"));
+    });
+  });
+  group("addParametersToUrl", () {
+    test("Add parameters to Uri Url without parameters", () {
+      // Arrange
+      String stringUrl = "https://www.google.com/helloworld";
+      Map<String, String> parameters = {"foo": "bar", "num": "0"};
+      Uri url = Uri.parse(stringUrl);
+
+      // Act
+      Uri parameterUri = addParametersToUrl(url, parameters);
+
+      // Assert
+      Uri expectedUrl = Uri.https("www.google.com", "/helloworld", parameters);
+      expect(parameterUri, equals(expectedUrl));
+    });
+    test("Add parameters to Uri Url with parameters", () {
+      // Arrange
+      String authority = "www.google.com";
+      String unencodedPath = "/helloworld";
+      Map<String, String> someParameters = {"foo": "bar"};
+      Map<String, String> otherParameters = {"num": "0"};
+      Uri url = Uri.https(authority, unencodedPath, someParameters);
+
+      // Act
+      Uri parameterUri = addParametersToUrl(url, otherParameters);
+
+      // Assert
+      Map<String, String> allParameters = {"foo": "bar", "num": "0"};
+      Uri expectedUrl = Uri.https("www.google.com", "/helloworld", allParameters);
+      expect(parameterUri, equals(expectedUrl));
     });
   });
 }


### PR DESCRIPTION
### Changelog:
- Added new utils for adding parameters to URI objects.
- Added validation to check if url is either string or Uri which are the only supported types at the moment.

Closes #20  .