### PR TITLE
Fix: Convert shouldAttemptRetryOnResponse to a Future.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,14 +147,14 @@ class WeatherRepository {
 ```dart
 class ExpiredTokenRetryPolicy extends RetryPolicy {
   @override
-  Future<bool> shouldAttemptRetryOnResponse(Response response) {
+  Future<bool> shouldAttemptRetryOnResponse(Response response) async {
     if (response.statusCode == 401) {
       // Perform your token refresh here.
 
-      return Future.value(true);
+      return true;
     }
 
-    return Future.value(false);
+    return false;
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -147,14 +147,14 @@ class WeatherRepository {
 ```dart
 class ExpiredTokenRetryPolicy extends RetryPolicy {
   @override
-  bool shouldAttemptRetryOnResponse(Response response) {
+  Future<bool> shouldAttemptRetryOnResponse(Response response) {
     if (response.statusCode == 401) {
       // Perform your token refresh here.
 
-      return true;
+      return Future.value(true);
     }
 
-    return false;
+    return Future.value(false);
   }
 }
 ```

--- a/lib/http_client_with_interceptor.dart
+++ b/lib/http_client_with_interceptor.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
+
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
-import 'package:http_interceptor/models/models.dart';
 import 'package:http_interceptor/interceptor_contract.dart';
+import 'package:http_interceptor/models/models.dart';
 import 'package:http_interceptor/utils.dart';
 
 import 'http_methods.dart';
@@ -193,16 +194,16 @@ class HttpClientWithInterceptor extends http.BaseClient {
           : await send(request).timeout(requestTimeout);
 
       response = await Response.fromStream(stream);
-      if (retryPolicy != null 
-      && retryPolicy.maxRetryAttempts > _retryCount 
-      && retryPolicy.shouldAttemptRetryOnResponse(response)) {
+      if (retryPolicy != null &&
+          retryPolicy.maxRetryAttempts > _retryCount &&
+          await retryPolicy.shouldAttemptRetryOnResponse(response)) {
         _retryCount += 1;
         return _attemptRequest(request);
       }
     } catch (error) {
-      if (retryPolicy != null 
-      && retryPolicy.maxRetryAttempts > _retryCount 
-      && retryPolicy.shouldAttemptRetryOnException(error)) {
+      if (retryPolicy != null &&
+          retryPolicy.maxRetryAttempts > _retryCount &&
+          retryPolicy.shouldAttemptRetryOnException(error)) {
         _retryCount += 1;
         return _attemptRequest(request);
       } else {

--- a/lib/models/retry_policy.dart
+++ b/lib/models/retry_policy.dart
@@ -2,7 +2,6 @@ import 'package:http/http.dart';
 
 abstract class RetryPolicy {
   bool shouldAttemptRetryOnException(Exception reason) => false;
-  Future<bool> shouldAttemptRetryOnResponse(Response response) async =>
-      Future.value(false);
+  Future<bool> shouldAttemptRetryOnResponse(Response response) async => false;
   final int maxRetryAttempts = 1;
 }

--- a/lib/models/retry_policy.dart
+++ b/lib/models/retry_policy.dart
@@ -2,6 +2,7 @@ import 'package:http/http.dart';
 
 abstract class RetryPolicy {
   bool shouldAttemptRetryOnException(Exception reason) => false;
-  bool shouldAttemptRetryOnResponse(Response response) => false;
+  Future<bool> shouldAttemptRetryOnResponse(Response response) async =>
+      Future.value(false);
   final int maxRetryAttempts = 1;
 }

--- a/test/models/retry_policy_test.dart
+++ b/test/models/retry_policy_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_interceptor/http_interceptor.dart';
+
+main() {
+  RetryPolicy testObject;
+
+  setUp(() {
+    testObject = TestRetryPolicy();
+  });
+
+  group("maxRetryAttempts", () {
+    test("defaults to 1", () {
+      expect(testObject.maxRetryAttempts, 1);
+    });
+  });
+
+  group("shouldAttemptRetryOnException", () {
+    test("returns false by default", () {
+      expect(testObject.shouldAttemptRetryOnException(null), false);
+    });
+  });
+
+  group("shouldAttemptRetryOnResponse", () {
+    test("returns false by default", () async {
+      expect(await testObject.shouldAttemptRetryOnResponse(null), false);
+    });
+  });
+}
+
+class TestRetryPolicy extends RetryPolicy {}


### PR DESCRIPTION
Convert shouldAttemptRetryOnResponse to return a Future so that a token refresh can happen asynchronously.