### PR TITLE
Fix: Custom class usage.

### DIFF
--- a/lib/http_client_with_interceptor.dart
+++ b/lib/http_client_with_interceptor.dart
@@ -211,7 +211,8 @@ class HttpClientWithInterceptor extends BaseClient {
       response = await Response.fromStream(stream);
       if (retryPolicy != null &&
           retryPolicy.maxRetryAttempts > _retryCount &&
-          await retryPolicy.shouldAttemptRetryOnResponse(response)) {
+          await retryPolicy.shouldAttemptRetryOnResponse(
+              ResponseData.fromHttpResponse(response))) {
         _retryCount += 1;
         return _attemptRequest(request);
       }

--- a/lib/models/retry_policy.dart
+++ b/lib/models/retry_policy.dart
@@ -1,7 +1,8 @@
-import 'package:http/http.dart';
+import 'package:http_interceptor/models/models.dart';
 
 abstract class RetryPolicy {
   bool shouldAttemptRetryOnException(Exception reason) => false;
-  Future<bool> shouldAttemptRetryOnResponse(Response response) async => false;
+  Future<bool> shouldAttemptRetryOnResponse(ResponseData response) async =>
+      false;
   final int maxRetryAttempts = 1;
 }


### PR DESCRIPTION
## 📝 Changelog:
- Modified retry policy to use the custom response data class instead of http's default response.