### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.1
+
+* Fixed: Retry Policy's `shouldAttemptRetryOnResponse` was synchronous which would not allow async token updates.
+* Fixed: Retry Policy would only trigger once when using `HttpClientWithInterceptor`.
+* Fixed: Retry Policy would use the `http` Response class, which would force plugin users to add http plugin separately.
+* Experimental: `badCertificateCallback` allows you to use self-signing certificates.
+
 ## 0.3.0
 
 * Added: RetryPolicy. It allows to attempt retries on a request when an exception occurs or when a condition from the response is met.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ class WeatherRepository {
 ```dart
 class ExpiredTokenRetryPolicy extends RetryPolicy {
   @override
-  Future<bool> shouldAttemptRetryOnResponse(Response response) async {
+  Future<bool> shouldAttemptRetryOnResponse(ResponseData response) async {
     if (response.statusCode == 401) {
       // Perform your token refresh here.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is a plugin that lets you intercept the different requests and responses fr
   - [Building your own interceptor](#building-your-own-interceptor)
   - [Using your interceptor](#using-your-interceptor)
   - [Retrying requests](#retrying-requests)
+  - [Using self-signed certificates](#using-self-signed-certificates)
 - [Having trouble? Fill an issue](#troubleshooting)
 
 ## Installation
@@ -160,6 +161,34 @@ class ExpiredTokenRetryPolicy extends RetryPolicy {
 ```
 
 You can also set the maximum amount of retry attempts with `maxRetryAttempts` property or override the `shouldAttemptRetryOnException` if you want to retry the request after it failed with an exception.
+
+### Using self signed certificates
+
+ **(EXPERIMENTAL ⚗️)** This plugin allows you to override the default `badCertificateCallback` provided by Dart's `io` package, this is really useful when working with self-signed certificates in your server. This can be done by sending a the callback to the HttpInterceptor builder functions. This feature is marked as experimental and **might be subject to change before release 1.0.0 comes**.
+
+```dart
+class WeatherRepository {
+
+  Future<Map<String, dynamic>> fetchCityWeather(int id) async {
+    var parsedWeather;
+    try {
+      var response = await HttpWithInterceptor.build(
+              interceptors: [WeatherApiInterceptor()],
+              badCertificateCallback: (certificate, host, port) => true)
+          .get("$baseUrl/weather", params: {'id': "$id"});
+      if (response.statusCode == 200) {
+        parsedWeather = json.decode(response.body);
+      } else {
+        throw Exception("Error while fetching. \n ${response.body}");
+      }
+    } catch (e) {
+      print(e);
+    }
+    return parsedWeather;
+  }
+
+}
+```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ class WeatherRepository {
 ```dart
 class ExpiredTokenRetryPolicy extends RetryPolicy {
   @override
-  bool shouldAttemptRetryOnResponse(Response response) {
+  Future<bool> shouldAttemptRetryOnResponse(Response response) async {
     if (response.statusCode == 401) {
       // Perform your token refresh here.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.13"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.14.12"
   convert:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.3.1"
   http_parser:
     dependency: transitive
     description:
@@ -101,7 +101,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.12"
   matcher:
     dependency: transitive
     description:
@@ -143,7 +143,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -155,7 +155,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.7.0"
   stack_trace:
     dependency: transitive
     description:
@@ -190,7 +190,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:
@@ -211,6 +211,6 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.1"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/lib/http_client_with_interceptor.dart
+++ b/lib/http_client_with_interceptor.dart
@@ -226,6 +226,7 @@ class HttpClientWithInterceptor extends BaseClient {
       }
     }
 
+    _retryCount = 0;
     return response;
   }
 

--- a/lib/http_client_with_interceptor.dart
+++ b/lib/http_client_with_interceptor.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
+
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
-import 'package:http_interceptor/models/models.dart';
 import 'package:http_interceptor/interceptor_contract.dart';
+import 'package:http_interceptor/models/models.dart';
 import 'package:http_interceptor/utils.dart';
 
 import 'http_methods.dart';
@@ -193,16 +194,16 @@ class HttpClientWithInterceptor extends http.BaseClient {
           : await send(request).timeout(requestTimeout);
 
       response = await Response.fromStream(stream);
-      if (retryPolicy != null 
-      && retryPolicy.maxRetryAttempts > _retryCount 
-      && retryPolicy.shouldAttemptRetryOnResponse(response)) {
+      if (retryPolicy != null &&
+          retryPolicy.maxRetryAttempts > _retryCount &&
+          await retryPolicy.shouldAttemptRetryOnResponse(response)) {
         _retryCount += 1;
         return _attemptRequest(request);
       }
     } catch (error) {
-      if (retryPolicy != null 
-      && retryPolicy.maxRetryAttempts > _retryCount 
-      && retryPolicy.shouldAttemptRetryOnException(error)) {
+      if (retryPolicy != null &&
+          retryPolicy.maxRetryAttempts > _retryCount &&
+          retryPolicy.shouldAttemptRetryOnException(error)) {
         _retryCount += 1;
         return _attemptRequest(request);
       } else {

--- a/lib/http_client_with_interceptor.dart
+++ b/lib/http_client_with_interceptor.dart
@@ -211,7 +211,8 @@ class HttpClientWithInterceptor extends BaseClient {
       response = await Response.fromStream(stream);
       if (retryPolicy != null &&
           retryPolicy.maxRetryAttempts > _retryCount &&
-          await retryPolicy.shouldAttemptRetryOnResponse(response)) {
+          await retryPolicy.shouldAttemptRetryOnResponse(
+              ResponseData.fromHttpResponse(response))) {
         _retryCount += 1;
         return _attemptRequest(request);
       }

--- a/lib/models/retry_policy.dart
+++ b/lib/models/retry_policy.dart
@@ -2,6 +2,6 @@ import 'package:http/http.dart';
 
 abstract class RetryPolicy {
   bool shouldAttemptRetryOnException(Exception reason) => false;
-  bool shouldAttemptRetryOnResponse(Response response) => false;
+  Future<bool> shouldAttemptRetryOnResponse(Response response) async => false;
   final int maxRetryAttempts = 1;
 }

--- a/lib/models/retry_policy.dart
+++ b/lib/models/retry_policy.dart
@@ -1,7 +1,8 @@
-import 'package:http/http.dart';
+import 'package:http_interceptor/models/models.dart';
 
 abstract class RetryPolicy {
   bool shouldAttemptRetryOnException(Exception reason) => false;
-  Future<bool> shouldAttemptRetryOnResponse(Response response) async => false;
+  Future<bool> shouldAttemptRetryOnResponse(ResponseData response) async =>
+      false;
   final int maxRetryAttempts = 1;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.13"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.14.12"
   convert:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   effective_dart:
     dependency: "direct dev"
     description:
@@ -94,7 +94,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.12"
   matcher:
     dependency: transitive
     description:
@@ -136,7 +136,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -148,7 +148,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.7.0"
   stack_trace:
     dependency: transitive
     description:
@@ -183,7 +183,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:
@@ -204,6 +204,6 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.1"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: http_interceptor
 description: A lightweight, simple plugin that allows you to intercept request and response objects and modify them if desired.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/CodingAleCR/http_interceptor
 issue_tracker: https://github.com/CodingAleCR/http_interceptor/issues
 repository: https://github.com/CodingAleCR/http_interceptor

--- a/test/models/retry_policy_test.dart
+++ b/test/models/retry_policy_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_interceptor/http_interceptor.dart';
+
+main() {
+  RetryPolicy testObject;
+
+  setUp(() {
+    testObject = TestRetryPolicy();
+  });
+
+  group("maxRetryAttempts", () {
+    test("defaults to 1", () {
+      expect(testObject.maxRetryAttempts, 1);
+    });
+  });
+
+  group("shouldAttemptRetryOnException", () {
+    test("returns false by default", () {
+      expect(testObject.shouldAttemptRetryOnException(null), false);
+    });
+  });
+
+  group("shouldAttemptRetryOnResponse", () {
+    test("returns false by default", () async {
+      expect(await testObject.shouldAttemptRetryOnResponse(null), false);
+    });
+  });
+}
+
+class TestRetryPolicy extends RetryPolicy {}


### PR DESCRIPTION
## 📝 Changelog
* Fixed: Retry Policy's `shouldAttemptRetryOnResponse` was synchronous which would not allow async token updates. (Thanks to @AsynchronySuperWes! 🎉)
* Fixed: Retry Policy would only trigger once when using `HttpClientWithInterceptor`.
* Fixed: Retry Policy would use the `http` Response class, which would force plugin users to add http plugin separately.
* Experimental: `badCertificateCallback` allows you to use self-signing certificates.