### PR TITLE
Use queryParametersAll when building RequestData

### DIFF
--- a/lib/models/request_data.dart
+++ b/lib/models/request_data.dart
@@ -27,7 +27,7 @@ class RequestData {
 
   factory RequestData.fromHttpRequest(Request request) {
     var params = Map<String, dynamic>();
-    request.url.queryParameters.forEach((key, value) {
+    request.url.queryParametersAll.forEach((key, value) {
       params[key] = value;
     });
     String baseUrl = request.url.origin + request.url.path;

--- a/test/models/request_data_test.dart
+++ b/test/models/request_data_test.dart
@@ -67,6 +67,23 @@ main() {
           equals(
               "https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3"));
     });
+    test("can be instantiated from HTTP GET Request with multiple parameters with same key", () {
+      // Arrange
+      Uri url = Uri.parse(
+          "https://www.google.com/helloworld?name=Hugo&type=2&type=3&type=4");
+
+      Request request = Request("GET", url);
+      RequestData requestData;
+
+      // Act
+      requestData = RequestData.fromHttpRequest(request);
+
+      // Assert
+      expect(
+          requestData.url,
+          equals(
+              "https://www.google.com/helloworld?name=Hugo&type=2&type=3&type=4"));
+    });
     test("correctly creates the request URL string", () {
       // Arrange
       Uri url = Uri.parse(


### PR DESCRIPTION
When passing params with a list as value, it will only add the last item of that list as a param when using `url.queryParameters`. With `queryParametersAll` it will keep that list. Each item of that list will then be added as a query param.