### PR TITLE
Use a pool for connections

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -198,7 +198,7 @@ packages:
     source: hosted
     version: "1.11.1"
   pool:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pool
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   http: ^0.13.3
+  pool: ^1.5.0
 
 dev_dependencies:
   test: ^1.17.5


### PR DESCRIPTION
I needed a way to make requests run in a sequence, not parallel.
This is more explained in the [issue](https://github.com/CodingAleCR/http_interceptor/issues/92) here.

The changes here introduce a `Pool`, so you can limit the amount of active requests by setting `maxActiveRequests`.
By default this is 32, feel free to change this or skip the pool altogether if not set.

This code for example will make sure all requests, including for example retrieving a token in a `RetryPolicy` will run one by one.

```
return InterceptedClient.build(
    interceptors: [
        ApiLoggingInterceptor(),
        AuthenticationInterceptor(),
    ],
    requestTimeout: HTTP_TIMEOUT,
    retryPolicy: NewTokenRetryPolicy(),
    maxActiveRequests: 1,
);
```

To get a token in `RetryPolicy` I use a seperate `InterceptedClient` which is also limited to one request.