### PR TITLE
Implement interception for `send` and MultipartRequests

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:http_interceptor/http_interceptor.dart';
-import 'package:http_interceptor/models/streamed_response_data.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'credentials.dart'; // If you are going to run this example you need to replace the key.
 import 'cities.dart'; // This is just a List of Maps that contains the suggested cities.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:http_interceptor/http_interceptor.dart';
+import 'package:http_interceptor/models/streamed_response_data.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'credentials.dart'; // If you are going to run this example you need to replace the key.
 import 'cities.dart'; // This is just a List of Maps that contains the suggested cities.
@@ -319,6 +320,13 @@ class LoggerInterceptor implements InterceptorContract {
     print(data.toString());
     return data;
   }
+
+  @override
+  Future<StreamedResponseData> interceptStreamedResponse({required StreamedResponseData data}) async {
+    print("----- Response -----");
+    print(data.toString());
+    return data;
+  }
 }
 
 const String appToken = "TOKEN";
@@ -342,6 +350,9 @@ class WeatherApiInterceptor implements InterceptorContract {
   @override
   Future<ResponseData> interceptResponse({required ResponseData data}) async =>
       data;
+
+  @override
+  Future<StreamedResponseData> interceptStreamedResponse({required StreamedResponseData data}) async => data;
 }
 
 class ExpiredTokenRetryPolicy extends RetryPolicy {

--- a/lib/http/intercepted_client.dart
+++ b/lib/http/intercepted_client.dart
@@ -182,7 +182,6 @@ class InterceptedClient extends BaseClient {
     });
   }
 
-  // TODO(codingalecr): Implement interception from `send` method.
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
     var response = await _attemptStreamedRequest(request);
@@ -243,8 +242,8 @@ class InterceptedClient extends BaseClient {
       final interceptedRequest = await _interceptRequest(request);
 
       var stream = requestTimeout == null
-          ? await send(interceptedRequest)
-          : await send(interceptedRequest).timeout(requestTimeout!);
+          ? await _inner.send(interceptedRequest)
+          : await _inner.send(interceptedRequest).timeout(requestTimeout!);
 
       response = await Response.fromStream(stream);
       if (retryPolicy != null &&
@@ -277,8 +276,8 @@ class InterceptedClient extends BaseClient {
       final interceptedRequest = await _interceptRequest(request);
 
       response = requestTimeout == null
-          ? await send(interceptedRequest)
-          : await send(interceptedRequest).timeout(requestTimeout!);
+          ? await _inner.send(interceptedRequest)
+          : await _inner.send(interceptedRequest).timeout(requestTimeout!);
 
       if (retryPolicy != null &&
           retryPolicy!.maxRetryAttempts > _retryCount &&

--- a/lib/http/intercepted_client.dart
+++ b/lib/http/intercepted_client.dart
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 import 'package:http/http.dart';
 import 'package:http_interceptor/models/models.dart';
 import 'package:http_interceptor/extensions/extensions.dart';
-import 'package:http_interceptor/models/streamed_response_data.dart';
 
 import 'http_methods.dart';
 import 'interceptor_contract.dart';

--- a/lib/http/interceptor_contract.dart
+++ b/lib/http/interceptor_contract.dart
@@ -1,4 +1,5 @@
 import 'package:http_interceptor/models/models.dart';
+import 'package:http_interceptor/models/streamed_response_data.dart';
 
 ///Interceptor interface to create custom Interceptor for http.
 ///Extend this class and override the functions that you want
@@ -29,4 +30,9 @@ abstract class InterceptorContract {
   Future<RequestData> interceptRequest({required RequestData data});
 
   Future<ResponseData> interceptResponse({required ResponseData data});
+
+  Future<StreamedResponseData> interceptStreamedResponse({required StreamedResponseData data}) async {
+    final response = await interceptResponse(data: data.toResponseData());
+    return StreamedResponseData.fromResponseData(response, data.stream);
+  }
 }

--- a/lib/http/interceptor_contract.dart
+++ b/lib/http/interceptor_contract.dart
@@ -1,5 +1,4 @@
 import 'package:http_interceptor/models/models.dart';
-import 'package:http_interceptor/models/streamed_response_data.dart';
 
 ///Interceptor interface to create custom Interceptor for http.
 ///Extend this class and override the functions that you want

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -2,3 +2,4 @@ export 'request_data.dart';
 export 'response_data.dart';
 export 'http_interceptor_exception.dart';
 export 'retry_policy.dart';
+export 'streamed_response_data.dart';

--- a/lib/models/streamed_response_data.dart
+++ b/lib/models/streamed_response_data.dart
@@ -1,0 +1,104 @@
+import 'dart:typed_data';
+
+import 'package:http/http.dart';
+import 'package:http_interceptor/http/http.dart';
+import 'package:http_interceptor/http_interceptor.dart';
+import 'package:http_interceptor/models/request_data.dart';
+
+/// A class that mimics a streamed HTTP Response in order to intercept it's data.
+class StreamedResponseData {
+  /// The stream comprising the body of this response.
+  Stream<List<int>> stream;
+
+  /// The HTTP status code for this response.
+  int statusCode;
+
+  Map<String, String>? headers;
+
+  /// The size of the response body, in bytes.
+  ///
+  /// If the size of the request is not known in advance, this is `null`.
+  int? contentLength;
+
+  bool? isRedirect;
+
+  /// Whether the server requested that a persistent connection be maintained.
+  bool? persistentConnection;
+
+  /// The (frozen) request that triggered this response.
+  RequestData? request;
+
+  /// Creates a new response data with body bytes.
+  StreamedResponseData(
+    this.stream,
+    this.statusCode, {
+    this.headers,
+    this.contentLength,
+    this.isRedirect,
+    this.persistentConnection,
+    this.request,
+  });
+
+  /// Method of the request that triggered this response.
+  Method? get method => request?.method;
+
+  /// URL as String of the request that triggered this response.
+  String? get url => request?.url;
+
+  /// Creates a new response data from an HTTP response.
+  factory StreamedResponseData.fromHttpResponse(StreamedResponse response) {
+    return StreamedResponseData(
+      response.stream,
+      response.statusCode,
+      headers: response.headers,
+      contentLength: response.contentLength,
+      isRedirect: response.isRedirect,
+      persistentConnection: response.persistentConnection,
+      request: (response.request != null) ? RequestData.fromHttpRequest(response.request!) : null,
+    );
+  }
+
+  /// Converts this response data to an HTTP response.
+  StreamedResponse toHttpResponse() {
+    return StreamedResponse(
+      stream,
+      statusCode,
+      headers: headers!,
+      persistentConnection: persistentConnection!,
+      isRedirect: isRedirect!,
+      contentLength: contentLength,
+      request: request?.toHttpRequest(),
+    );
+  }
+
+  factory StreamedResponseData.fromResponseData(ResponseData response, Stream<List<int>> stream) {
+    return StreamedResponseData(
+      stream,
+      response.statusCode,
+      headers: response.headers,
+      persistentConnection: response.persistentConnection,
+      isRedirect: response.isRedirect,
+      request: response.request,
+      contentLength: response.contentLength,
+    );
+  }
+
+  /// Converts to synchronous response data, with no body
+  ResponseData toResponseData() {
+    return ResponseData(
+      Uint8List(0),
+      statusCode,
+      headers: headers,
+      contentLength: contentLength,
+      isRedirect: isRedirect,
+      persistentConnection: persistentConnection,
+      request: request,
+    );
+  }
+
+  /// Convenient toString implementation for logging.
+  @override
+  String toString() {
+    return 'StreamedResponseData { $method, $url, $headers, $statusCode, $request }';
+  }
+}

--- a/test/models/request_data_test.dart
+++ b/test/models/request_data_test.dart
@@ -10,8 +10,7 @@ main() {
       RequestData requestData;
 
       // Act
-      requestData = RequestData(
-          method: Method.GET, baseUrl: "https://www.google.com/helloworld");
+      requestData = RequestData(method: Method.GET, baseUrl: "https://www.google.com/helloworld");
 
       // Assert
       expect(requestData, isNotNull);
@@ -44,13 +43,11 @@ main() {
       // Assert
       expect(requestData, isNotNull);
       expect(requestData.method, equals(Method.GET));
-      expect(
-          requestData.url, equals("https://www.google.com/helloworld/foo/bar"));
+      expect(requestData.url, equals("https://www.google.com/helloworld/foo/bar"));
     });
     test("can be instantiated from HTTP GET Request with parameters", () {
       // Arrange
-      Uri url = Uri.parse(
-          "https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3");
+      Uri url = Uri.parse("https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3");
 
       Request request = Request("GET", url);
       RequestData requestData;
@@ -62,15 +59,11 @@ main() {
       expect(requestData, isNotNull);
       expect(requestData.method, equals(Method.GET));
       expect(requestData.baseUrl, equals("https://www.google.com/helloworld"));
-      expect(
-          requestData.url,
-          equals(
-              "https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3"));
+      expect(requestData.url, equals("https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3"));
     });
     test("can be instantiated from HTTP GET Request with multiple parameters with same key", () {
       // Arrange
-      Uri url = Uri.parse(
-          "https://www.google.com/helloworld?name=Hugo&type=2&type=3&type=4");
+      Uri url = Uri.parse("https://www.google.com/helloworld?name=Hugo&type=2&type=3&type=4");
 
       Request request = Request("GET", url);
       RequestData requestData;
@@ -79,15 +72,11 @@ main() {
       requestData = RequestData.fromHttpRequest(request);
 
       // Assert
-      expect(
-          requestData.url,
-          equals(
-              "https://www.google.com/helloworld?name=Hugo&type=2&type=3&type=4"));
+      expect(requestData.url, equals("https://www.google.com/helloworld?name=Hugo&type=2&type=3&type=4"));
     });
     test("correctly creates the request URL string", () {
       // Arrange
-      Uri url = Uri.parse(
-          "https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3");
+      Uri url = Uri.parse("https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3");
 
       Request request = Request("GET", url);
       RequestData requestData;
@@ -98,10 +87,44 @@ main() {
       // Assert
       expect(requestData, isNotNull);
       expect(requestData.method, equals(Method.GET));
-      expect(
-          requestData.url,
-          equals(
-              "https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3"));
+      expect(requestData.url, equals("https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3"));
+    });
+
+    group('MultipartRequest', () {
+      test('correctly creates request data', () {
+        // Arrange
+        final url = Uri.parse("https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3");
+        final multipartRequest = MultipartRequest("POST", url);
+
+        // Act
+        final requestData = RequestData.fromHttpRequest(multipartRequest);
+
+        // Assert
+        expect(requestData.url, "https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3");
+        expect(requestData.method, equals(Method.POST));
+        expect(requestData.body, isA<MultipartBody>());
+      });
+
+      test('correctly creates multipart request', () {
+        // Arrange
+        final url = Uri.parse("https://www.google.com/helloworld?key=123ABC&name=Hugo&type=3");
+        final multipartRequest = MultipartRequest("PUT", url);
+        final fields = {"foo": "bar"};
+        final file = MultipartFile.fromString("someFile", "test-string");
+        multipartRequest.fields.addAll(fields);
+        multipartRequest.files.add(file);
+
+        // Act
+        final requestData = RequestData.fromHttpRequest(multipartRequest);
+        final request = requestData.toHttpRequest() as MultipartRequest; // cast does not affect runtimeType, hence test is still valid
+
+        // Assert
+        expect(request, isA<MultipartRequest>());
+        expect(request.url, equals(url));
+        expect(request.method, "PUT");
+        expect(request.fields, equals(fields));
+        expect(request.files, equals([file]));
+      });
     });
   });
 }


### PR DESCRIPTION
Hi there :wave: 

I recently started using your package, since I was missing some decent standalone http interceptors for flutter and your package fits the description neatly.

## Problem

I stumbled upon the issue of unauthenticated file upload requests (I use an interceptor for auth headers) and learned that the `send` method has no implemented interception. Since the job and code did not seem to difficult, I tried to implement those.

## What was done

Firstly, i changed the `_sendUnstreamed` method to not use the `send` method directly (which just calls `_inner.send` anyways), but rather make a call to `_inner.send`

Since send returns `StreamedResponse` I duplicated and changed parts of the interception logic to handle `StreamedResponse` instead of normal `Response` .

I added a `StreamedResponseData` class, which can be "converted" to a normal `ResponseData`, just without a body/bodyBytes (since that would not make sense in the case of a streamed body). I did this, so we can still handle a `StreamedResponse` like a normal one, modifying headers and all that, but dont have access to the body.

In case someone wants to modify or access the streamed body, I extended the `InterceptorContract` to include a `interceptStreamedResponse` method. I took some architectural liberties here and this could probably be implemented differently, by making a subclassed `StreamedInterceptorContract` for example.

Then I also had to make some changes to the `RequestData` class, in order to support Multipart request.
I did this, by simply rearranging some ifs. The `fields` and `files` are put into a `MultipartBody` object, that is put into the body.