### PR TITLE
feat: Simplify configuration of delay between retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ http_interceptor: <latest>
 - 🍦 Compatible with vanilla Dart projects or Flutter projects.
 - 🎉 Null-safety.
 - ⏲ Timeout configuration with duration and timeout functions.
+- ⏳ Configure the delay for each retry attempt.
 
 ## Usage
 
@@ -226,6 +227,17 @@ class ExpiredTokenRetryPolicy extends RetryPolicy {
 ```
 
 You can also set the maximum amount of retry attempts with `maxRetryAttempts` property or override the `shouldAttemptRetryOnException` if you want to retry the request after it failed with an exception.
+
+Sometimes it is helpful to have a cool-down phase between multiple requests. This delay could for example also differ between the first and the second retry attempt as shown in the following example.
+
+```dart
+class ExpiredTokenRetryPolicy extends RetryPolicy {
+  @override
+  Duration delayRetryAttemptOnResponse({required int retryAttempt}) {
+    return const Duration(milliseconds: 250) * math.pow(2.0, retryAttempt);
+  }
+}
+```
 
 ### Using self signed certificates
 

--- a/example/lib/weather_app.dart
+++ b/example/lib/weather_app.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:http_interceptor/http_interceptor.dart';
@@ -342,6 +343,11 @@ class ExpiredTokenRetryPolicy extends RetryPolicy {
     log(reason.toString());
 
     return false;
+  }
+
+  @override
+  Duration delayRetryAttemptOnResponse({required int retryAttempt}) {
+    return const Duration(milliseconds: 250) * math.pow(2.0, retryAttempt);
   }
 
   @override

--- a/lib/http/intercepted_client.dart
+++ b/lib/http/intercepted_client.dart
@@ -285,6 +285,8 @@ class InterceptedClient extends BaseClient {
           retryPolicy!.maxRetryAttempts > _retryCount &&
           await retryPolicy!.shouldAttemptRetryOnResponse(response)) {
         _retryCount += 1;
+        await Future.delayed(retryPolicy!
+            .delayRetryAttemptOnResponse(retryAttempt: _retryCount));
         return _attemptRequest(request);
       }
     } on Exception catch (error) {
@@ -292,6 +294,8 @@ class InterceptedClient extends BaseClient {
           retryPolicy!.maxRetryAttempts > _retryCount &&
           await retryPolicy!.shouldAttemptRetryOnException(error, request)) {
         _retryCount += 1;
+        await Future.delayed(retryPolicy!
+            .delayRetryAttemptOnException(retryAttempt: _retryCount));
         return _attemptRequest(request);
       } else {
         rethrow;

--- a/lib/http_interceptor.dart
+++ b/lib/http_interceptor.dart
@@ -7,7 +7,6 @@ export './extensions/base_response_none.dart'
     if (dart.library.io) './extensions/base_response_io.dart';
 export './extensions/multipart_request.dart';
 export './extensions/request.dart';
-export './extensions/request.dart';
 export './extensions/response.dart';
 export './extensions/streamed_request.dart';
 export './extensions/streamed_response.dart';

--- a/lib/models/retry_policy.dart
+++ b/lib/models/retry_policy.dart
@@ -47,4 +47,10 @@ abstract class RetryPolicy {
 
   /// Number of maximum request attempts that can be retried.
   final int maxRetryAttempts = 1;
+
+  Duration delayRetryAttemptOnException({required int retryAttempt}) =>
+      Duration.zero;
+
+  Duration delayRetryAttemptOnResponse({required int retryAttempt}) =>
+      Duration.zero;
 }

--- a/test/models/retry_policy_test.dart
+++ b/test/models/retry_policy_test.dart
@@ -14,6 +14,26 @@ main() {
     });
   });
 
+  group("delayRetryAttemptOnException", () {
+    test("returns no delay by default", () async {
+      // Act
+      final result = testObject.delayRetryAttemptOnException(retryAttempt: 0);
+
+      // Assert
+      expect(result, Duration.zero);
+    });
+  });
+
+  group("delayRetryAttemptOnResponse", () {
+    test("returns no delay by default", () async {
+      // Act
+      final result = testObject.delayRetryAttemptOnResponse(retryAttempt: 0);
+
+      // Assert
+      expect(result, Duration.zero);
+    });
+  });
+
   group("shouldAttemptRetryOnException", () {
     test("returns false by default", () async {
       expect(


### PR DESCRIPTION
This PR adds the possibility to configure a delay between retries. Sometimes it is helpful to have a "cool down" phase between multiple requests. This could for example also differ between the first and the second retry attempt as shown in `example/lib/weather_app.dart`.