### PR TITLE
Fix type 'Response' is not a subtype of type 'StreamedResponse' in type cast

### DIFF
--- a/lib/http/intercepted_client.dart
+++ b/lib/http/intercepted_client.dart
@@ -215,7 +215,7 @@ class InterceptedClient extends BaseClient {
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
-    final response = await _attemptRequest(request);
+    final response = await _attemptRequest(request, isStream: true);
 
     final interceptedResponse = await _interceptResponse(response);
 
@@ -266,7 +266,8 @@ class InterceptedClient extends BaseClient {
 
   /// Attempts to perform the request and intercept the data
   /// of the response
-  Future<BaseResponse> _attemptRequest(BaseRequest request) async {
+  Future<BaseResponse> _attemptRequest(BaseRequest request,
+      {bool isStream = false}) async {
     BaseResponse response;
     try {
       // Intercept request
@@ -278,8 +279,7 @@ class InterceptedClient extends BaseClient {
               .send(interceptedRequest)
               .timeout(requestTimeout!, onTimeout: onRequestTimeout);
 
-      response =
-          request is Request ? await Response.fromStream(stream) : stream;
+      response = isStream ? stream : await Response.fromStream(stream);
 
       if (retryPolicy != null &&
           retryPolicy!.maxRetryAttempts > _retryCount &&

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: ">=3.0.3 <4.0.0"
 
 dependencies:
-  http: ^1.0.0
+  http: ^1.1.0
 
 dev_dependencies:
   lints: ^2.1.1


### PR DESCRIPTION
flutter: type 'Response' is not a subtype of type 'StreamedResponse' in type cast
flutter: #0      InterceptedClient.send (package:http_interceptor/http/intercepted_client.dart:222:32)
<asynchronous suspension>