### PR TITLE
Fix "type 'Response' is not a subtype of type 'StreamedResponse' in type cast" after retrying a request

### DIFF
--- a/lib/http/intercepted_client.dart
+++ b/lib/http/intercepted_client.dart
@@ -293,7 +293,7 @@ class InterceptedClient extends BaseClient {
         _retryCount += 1;
         await Future.delayed(retryPolicy!
             .delayRetryAttemptOnResponse(retryAttempt: _retryCount));
-        return _attemptRequest(request);
+        return _attemptRequest(request, isStream: isStream);
       }
     } on Exception catch (error) {
       if (retryPolicy != null &&
@@ -302,7 +302,7 @@ class InterceptedClient extends BaseClient {
         _retryCount += 1;
         await Future.delayed(retryPolicy!
             .delayRetryAttemptOnException(retryAttempt: _retryCount));
-        return _attemptRequest(request);
+        return _attemptRequest(request, isStream: isStream);
       } else {
         rethrow;
       }


### PR DESCRIPTION
**Issue description:**
When you use the library in version `2.0.0` and create the`InterceptedClient` with a `retryPolicy` and then call the `send()` method it throws a `"type 'Response' is not a subtype of type 'StreamedResponse' in type cast"` exception after the `retryPolicy` was used to retry the request.

**Proposed fix:**
After https://github.com/CodingAleCR/http_interceptor/pull/132 the `_attemptRequest()` method has received an optional parameter `isStream` set by default to `false`. When the `retryPolicy` is invoked inside the method, the `_attemptRequest()` is recursively called again but the `isStream` parameter isn't passed through, but rather the default value is being used. Due to that even if you call `_attemptRequest(isStream: true)` then after using `retryPolicy` it will be called again but with the default value `false`, which then leads to the type cast error.

Hopefully, it could possibly fix the https://github.com/CodingAleCR/http_interceptor/issues/134 if it isn't resolved already 😉 