### PR TITLE
FIX: Fixed bad parsing of binary request bodies

### DIFF
--- a/lib/extensions/request.dart
+++ b/lib/extensions/request.dart
@@ -21,7 +21,13 @@ extension RequestCopyWith on Request {
     final copied = Request(
       method?.asString ?? this.method,
       url ?? this.url,
-    )..body = this.body;
+    )..bodyBytes = this.bodyBytes;
+
+    try {
+      copied.body = this.body;
+    } catch (e) {
+      // Do not try to get body as string when it is not parseable
+    }
 
     if (body != null) {
       copied.body = body;


### PR DESCRIPTION
Previous code always assumed that request's bodies were UTF-8 parseable.

This changes allows interceptors to decide whether they want to decode a request body by calling `.body` getter, and thus, triggering the Dart's native charset decoding.

For the rest of use-cases, for example, when only introducing some headers, `bodyBytes` passes unmodified and the `body` getter is never called, and a UTF-8 decoding exception avoided.