### PR TITLE
feat: pass request into conditional methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a plugin that lets you intercept the different requests and responses fr
 
 **Already using `http_interceptor`? Check out the [1.0.0 migration guide](./guides/migration_guide_1.0.0.md) for quick reference on the changes made and how to migrate your code.**
 
-- [http_interceptor](#http_interceptor)
+- [http\_interceptor](#http_interceptor)
   - [Quick Reference](#quick-reference)
   - [Installation](#installation)
   - [Features](#features)
@@ -67,9 +67,16 @@ import 'package:http_interceptor/http_interceptor.dart';
 
 ### Building your own interceptor
 
-In order to implement `http_interceptor` you need to implement the `InterceptorContract` and create your own interceptor. This abstract class has two methods: `interceptRequest`, which triggers before the http request is called; and `interceptResponse`, which triggers after the request is called, it has a response attached to it which the corresponding to said request. You could use this to do logging, adding headers, error handling, or many other cool stuff. It is important to note that after you proccess the request/response objects you need to return them so that `http` can continue the execute.
+In order to implement `http_interceptor` you need to implement the `InterceptorContract` and create your own interceptor. This abstract class has four methods:
 
-`interceptRequest` and `interceptResponse` use `FutureOr` syntax, which makes it easier to support both synchronous and asynchronous behaviors.
+ - `interceptRequest`, which triggers before the http request is called 
+ - `interceptResponse`, which triggers after the request is called, it has a response attached to it which the corresponding to said request;
+ 
+- `shouldInterceptRequest` and `shouldInterceptResponse`, which are used to determine if the request or response should be intercepted or not. These two methods are optional as they return `true` by default, but they can be useful if you want to conditionally intercept requests or responses based on certain criteria. 
+
+You could use this package to do logging, adding headers, error handling, or many other cool stuff. It is important to note that after you proccess the request/response objects you need to return them so that `http` can continue the execute.
+
+All four methods use `FutureOr` syntax, which makes it easier to support both synchronous and asynchronous behaviors.
 
 - Logging with interceptor:
 
@@ -120,6 +127,18 @@ class WeatherApiInterceptor implements InterceptorContract {
   required BaseResponse response,
   }) =>
       response;
+  
+  @override
+  FutureOr<bool> shouldInterceptRequest({required BaseRequest request}) async {
+    // You can conditionally intercept requests here
+    return true; // Intercept all requests
+  }
+
+  @override
+  FutureOr<bool> shouldInterceptResponse({required BaseResponse response}) async {
+    // You can conditionally intercept responses here
+    return true; // Intercept all responses
+  }
 }
 ```
 
@@ -143,6 +162,18 @@ class MultipartRequestInterceptor implements InterceptorContract {
       });
     }
     return response;
+  }
+
+  @override
+  FutureOr<bool> shouldInterceptRequest({required BaseRequest request}) async {
+    // You can conditionally intercept requests here
+    return true; // Intercept all requests
+  }
+
+  @override
+  FutureOr<bool> shouldInterceptResponse({required BaseResponse response}) async {
+    // You can conditionally intercept responses here
+    return true; // Intercept all responses
   }
 }
 ```

--- a/lib/http/intercepted_client.dart
+++ b/lib/http/intercepted_client.dart
@@ -316,7 +316,8 @@ class InterceptedClient extends BaseClient {
   Future<BaseRequest> _interceptRequest(BaseRequest request) async {
     BaseRequest interceptedRequest = request.copyWith();
     for (InterceptorContract interceptor in interceptors) {
-      if (await interceptor.shouldInterceptRequest()) {
+      if (await interceptor.shouldInterceptRequest(
+          request: interceptedRequest)) {
         interceptedRequest = await interceptor.interceptRequest(
           request: interceptedRequest,
         );
@@ -330,7 +331,8 @@ class InterceptedClient extends BaseClient {
   Future<BaseResponse> _interceptResponse(BaseResponse response) async {
     BaseResponse interceptedResponse = response;
     for (InterceptorContract interceptor in interceptors) {
-      if (await interceptor.shouldInterceptResponse()) {
+      if (await interceptor.shouldInterceptResponse(
+          response: interceptedResponse)) {
         interceptedResponse = await interceptor.interceptResponse(
           response: interceptedResponse,
         );

--- a/lib/http/intercepted_client.dart
+++ b/lib/http/intercepted_client.dart
@@ -389,7 +389,8 @@ class InterceptedClient extends BaseClient {
     BaseRequest interceptedRequest = request.copyWith();
     for (InterceptorContract interceptor in interceptors) {
       if (await interceptor.shouldInterceptRequest(
-          request: interceptedRequest)) {
+        request: interceptedRequest,
+      )) {
         interceptedRequest = await interceptor.interceptRequest(
           request: interceptedRequest,
         );
@@ -404,7 +405,8 @@ class InterceptedClient extends BaseClient {
     BaseResponse interceptedResponse = response;
     for (InterceptorContract interceptor in interceptors) {
       if (await interceptor.shouldInterceptResponse(
-          response: interceptedResponse)) {
+        response: interceptedResponse,
+      )) {
         interceptedResponse = await interceptor.interceptResponse(
           response: interceptedResponse,
         );

--- a/lib/models/interceptor_contract.dart
+++ b/lib/models/interceptor_contract.dart
@@ -41,4 +41,8 @@ abstract class InterceptorContract {
     required BaseResponse response,
   }) =>
       true;
+
+  FutureOr<BaseResponse> interceptResponse({
+    required BaseResponse response,
+  });
 }

--- a/lib/models/interceptor_contract.dart
+++ b/lib/models/interceptor_contract.dart
@@ -28,11 +28,17 @@ import 'package:http/http.dart';
 ///}
 ///```
 abstract class InterceptorContract {
-  FutureOr<bool> shouldInterceptRequest({required BaseRequest request}) => true;
+  FutureOr<bool> shouldInterceptRequest({
+    required BaseRequest request,
+  }) =>
+      true;
 
-  FutureOr<BaseRequest> interceptRequest({required BaseRequest request});
+  FutureOr<BaseRequest> interceptRequest({
+    required BaseRequest request,
+  });
 
-  FutureOr<bool> shouldInterceptResponse({required BaseResponse response}) => true;
-
-  FutureOr<BaseResponse> interceptResponse({required BaseResponse response});
+  FutureOr<bool> shouldInterceptResponse({
+    required BaseResponse response,
+  }) =>
+      true;
 }

--- a/lib/models/interceptor_contract.dart
+++ b/lib/models/interceptor_contract.dart
@@ -28,11 +28,11 @@ import 'package:http/http.dart';
 ///}
 ///```
 abstract class InterceptorContract {
-  FutureOr<bool> shouldInterceptRequest() => true;
+  FutureOr<bool> shouldInterceptRequest({required BaseRequest request}) => true;
 
   FutureOr<BaseRequest> interceptRequest({required BaseRequest request});
 
-  FutureOr<bool> shouldInterceptResponse() => true;
+  FutureOr<bool> shouldInterceptResponse({required BaseResponse response}) => true;
 
   FutureOr<BaseResponse> interceptResponse({required BaseResponse response});
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Version `2.0.0` introduced `shouldInterceptRequest` and `shouldInterceptResponse` as a conditional check before actually intercepting the response or request but the README hasnt been updated to mention these 2 methods.
- These two methods should be able to access the request/response we want to intercept.

## Proposed Changes:
- Add these two methods to the README.
- Add request/response as argument of the two methods.